### PR TITLE
Various small fixes from testing public rosdistro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ Docs: https://colcon-distro.readthedocs.io
 Example configuration:
 
 ```
+[general]
+parallelism = 12
+
 [distro]
-repository = "https://github.com/clearpathrobotics/rosdistro-snapshots"
-distributions = ['noetic', 'rolling']
+repository = "https://github.com/clearpathrobotics/rosdistro-snapshots.git"
+distributions = [ 'noetic', 'rolling' ]
+branches = [ 'snapshot/latest' ]
+python_version = 3
 
 [database]
 filename = "/var/tmp/distro.db"
@@ -25,7 +30,7 @@ repository = "file:///home/administrator/rosdistro_internal"
 distributions = [ 'noetic' ]
 ```
 
-You can also specify augmented package- and repository descriptor metadata to include, with:
+You can also specify package- and repository descriptor metadata to include, with:
 
 ```
 [cache]

--- a/colcon_distro/model.py
+++ b/colcon_distro/model.py
@@ -88,8 +88,9 @@ class Model:
             def _get_repo_states():
                 """ Generate getter coroutines for all repo states. """
                 for repo_name, repo_dict in distro_dict['repositories'].items():
-                    desc = RepositoryDescriptor.from_distro(repo_name, repo_dict['source'])
-                    yield self.get_repo_state(desc)
+                    if 'source' in repo_dict:
+                        desc = RepositoryDescriptor.from_distro(repo_name, repo_dict['source'])
+                        yield self.get_repo_state(desc)
 
             logger.info(f"Preparing cache for {dist_name}:{ref}.")
             repository_descriptors = await asyncio.gather(*_get_repo_states())
@@ -126,9 +127,6 @@ class Model:
                     repository_descriptor.packages = \
                         discover_augmented_packages(repository_descriptor.path)
                     augment_repository(repository_descriptor)
-
-            if not repository_descriptor.packages:
-                raise ModelError(f"No packages discovered in {repository_descriptor.url}.")
 
             # Insert it as a new row, which will set the repo_state_id metadata on it.
             await self.db.insert_repo_state(repository_descriptor)

--- a/colcon_distro/server.py
+++ b/colcon_distro/server.py
@@ -60,7 +60,7 @@ async def get_response_dict(model, dist, ref):
     }
 
 
-@app.route("/get/<dist:string>/<path:path>")
+@app.route("/get/<dist:str>/<path:path>")
 async def get_ref(request, dist: str, path: str):
     if m := re.match(r"^(.*)\.(yaml|json)", path):
         ref, requested_format = m.groups()
@@ -118,6 +118,7 @@ def main():
             port=args.port,
             return_asyncio_server=True
         )
+        await server.startup()
         return await server.serve_forever()
 
     try:


### PR DESCRIPTION
Miscellaneous fixes from testing against rosdistro-snapshots:

- Add a bitbucket downloader.
- Tolerate repositories with no `source` entry.
- Tolerate sources containing no packages.
- Work with Sanic v22.

Live instance: http://colcon-distro.ext.ottomotors.com/get/noetic/snapshot/20221009.json

FYI @iwanders